### PR TITLE
route fix

### DIFF
--- a/client.sh
+++ b/client.sh
@@ -4,5 +4,5 @@ echo "openshift client, docker and remote-viewer must be installed to use this s
 
 
 route=$(oc get route spice --template '{{.spec.host}}')
-sudo docker run --rm -d --net=host jpillora/chisel client ${route} 5900:127.0.0.1:5900
+sudo docker run -d --net=host jpillora/chisel client ${route} 5900:127.0.0.1:5900
 remote-viewer spice://127.0.0.1:5900

--- a/openshift-template.yaml
+++ b/openshift-template.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Template
 metadata:
@@ -189,7 +188,6 @@ objects:
   metadata:
     name: spice
   spec:
-    host: spice.router.default.svc.cluster.local
     port:
       targetPort: 8080-tcp
     to:


### PR DESCRIPTION
remotely accessible route ... also, had to modify `docker run`. 

```bash
$ docker run --rm -d --net=host jpillora/chisel client ${route} 5900:127.0.0.1:5900
Conflicting options: --rm and -d
```