### PR TITLE
Fixing script and template

### DIFF
--- a/client.sh
+++ b/client.sh
@@ -4,5 +4,13 @@ echo "openshift client, docker and remote-viewer must be installed to use this s
 
 
 route=$(oc get route spice --template '{{.spec.host}}')
-sudo docker run -d --net=host jpillora/chisel client ${route} 5900:127.0.0.1:5900
+sudo docker run -d --name spice-proxy-client --net=host jpillora/chisel client ${route} 5900:127.0.0.1:5900
+
+(sudo docker logs -f spice-proxy-client & ) | grep -q "Connected"
+
+PID=`ps -ef | grep "sudo docker logs" | grep -v 'grep' | awk '{print $2}'`
+sudo kill -9 ${PID}
+
 remote-viewer spice://127.0.0.1:5900
+
+sudo docker rm -f spice-proxy-client

--- a/openshift-template.yaml
+++ b/openshift-template.yaml
@@ -54,15 +54,8 @@ objects:
           ports:
           - containerPort: 8080
             protocol: TCP
-          resources: {}
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
         dnsPolicy: ClusterFirst
         restartPolicy: Always
-        schedulerName: default-scheduler
-        securityContext: {}
-        terminationGracePeriodSeconds: 30
-    test: false
     triggers:
     - type: ConfigChange
     - imageChangeParams:
@@ -110,8 +103,6 @@ objects:
       to:
         kind: ImageStreamTag
         name: vscode:latest
-    postCommit: {}
-    resources: {}
     runPolicy: Serial
     source:
       git:
@@ -137,51 +128,17 @@ objects:
     - from:
         kind: DockerImage
         name: docker.io/fedora:27
-      generation: 2
-      importPolicy: {}
       name: "27"
-      referencePolicy:
-        type: Source
 
 - apiVersion: v1
   kind: ImageStream
   metadata:
-    labels:
-      build: spice-base
     name: spice-base
-  spec:
-    lookupPolicy:
-      local: false
-    tags:
-    - annotations: null
-      from:
-        kind: ImageStreamTag
-        name: spice-base:latest
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
 
 - apiVersion: v1
   kind: ImageStream
   metadata:
-    creationTimestamp: null
-    generation: 1
     name: vscode
-  spec:
-    lookupPolicy:
-      local: false
-    tags:
-    - annotations: null
-      from:
-        kind: ImageStreamTag
-        name: vscode:latest
-      generation: null
-      importPolicy: {}
-      name: latest
-      referencePolicy:
-        type: ""
 
 - apiVersion: v1
   kind: Route


### PR DESCRIPTION
@tchughesiv this should fix the `oc new-app --template` problem.  And also a problem that I was seeing with the `chisel` not being connected before starting `remote-viewer`.

